### PR TITLE
Downgrade to Docker Compose 2 for compatibility with other projects

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 services:
 
   dev:


### PR DESCRIPTION
This commit downgrades the docker compose version from 3 to 2 so that this project is in line with our others. When we upgrade to 3 we should look to do it across the board to ensure we can still use Deko Docker to develop everything from one swift docker-compose up.